### PR TITLE
Fix map layer loading by including waterways data

### DIFF
--- a/components/MapWrapper.tsx
+++ b/components/MapWrapper.tsx
@@ -324,14 +324,17 @@ const MapWrapper: React.FC<MapWrapperProps> = ({
   }, [clusters, riskZones]);
 
   const contaminatedSegments = useMemo(() => {
-    if (!waterLoaded || !waterGeoms.length) return [] as { id: string; path: [number, number][] }[];
     const circles = [
       ...clusters.map(c => ({ center: c.center, radius: c.radius })),
       ...riskZones.map(r => ({ center: r.center, radius: r.radius })),
     ];
+    const sources: { id: string; path: [number, number][]; isPolygon: boolean }[] = [
+      ...waterGeoms.map(g => ({ id: g.id, path: g.path, isPolygon: g.isPolygon })),
+      ...waterways.map(w => ({ id: w.id, path: w.path, isPolygon: false })),
+    ];
     const segs: { id: string; path: [number, number][] }[] = [];
     let idx = 0;
-    for (const g of waterGeoms) {
+    for (const g of sources) {
       if (g.isPolygon) {
         if (g.path.some(p => insideAnyCircle(p, circles))) segs.push({ id: `${g.id}-${idx++}`, path: g.path });
       } else {
@@ -340,18 +343,21 @@ const MapWrapper: React.FC<MapWrapperProps> = ({
       }
     }
     return segs;
-  }, [waterLoaded, waterGeoms, clusters, riskZones]);
+  }, [waterGeoms, waterways, clusters, riskZones]);
 
   const waterAdjacentRiskSegments = useMemo(() => {
-    if (!waterLoaded || !waterGeoms.length) return [] as { id: string; path: [number, number][] }[];
     const circles = [
       ...clusters.map(c => ({ center: c.center, radius: c.radius })),
       ...riskZones.map(r => ({ center: r.center, radius: r.radius })),
     ];
     const buffer = 1700; // increased adjacent radius along water
+    const sources: { id: string; path: [number, number][]; isPolygon: boolean }[] = [
+      ...waterGeoms.map(g => ({ id: g.id, path: g.path, isPolygon: g.isPolygon })),
+      ...waterways.map(w => ({ id: w.id, path: w.path, isPolygon: false })),
+    ];
     const segs: { id: string; path: [number, number][] }[] = [];
     let idx = 0;
-    for (const g of waterGeoms) {
+    for (const g of sources) {
       if (g.isPolygon) {
         if (g.path.some(p => insideAnyCircle(p, circles))) segs.push({ id: `${g.id}-${idx++}`, path: g.path });
       } else {
@@ -360,7 +366,7 @@ const MapWrapper: React.FC<MapWrapperProps> = ({
       }
     }
     return segs;
-  }, [waterLoaded, waterGeoms, clusters, riskZones]);
+  }, [waterGeoms, waterways, clusters, riskZones]);
 
   return (
     <MapContainer center={mapCenter} zoom={13} scrollWheelZoom={true} className="h-full w-full">


### PR DESCRIPTION
## Purpose

Fix an issue where the map was not loading risk zones, contaminated water layers, contaminated zones, and water adjacent risk layers on opening. The user reported that these critical map layers were failing to display properly when the map was first loaded.

## Code changes

- **Removed waterLoaded dependency**: Eliminated the `waterLoaded` check that was preventing layer calculations from running
- **Added waterways data source**: Combined `waterGeoms` and `waterways` into a unified `sources` array for both contaminated segments and water adjacent risk segments
- **Updated dependency arrays**: Modified useMemo dependencies to include `waterways` alongside existing dependencies (`waterGeoms`, `clusters`, `riskZones`)
- **Unified data processing**: Both `contaminatedSegments` and `waterAdjacentRiskSegments` now process the combined water data sources consistently

These changes ensure that all water-related layers (contaminated zones, risk zones, and adjacent areas) are properly calculated and displayed when the map loads.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8010633e9e2f4cb297a04921d477e18f/mystic-haven)

👀 [Preview Link](https://8010633e9e2f4cb297a04921d477e18f-mystic-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8010633e9e2f4cb297a04921d477e18f</projectId>-->
<!--<branchName>mystic-haven</branchName>-->